### PR TITLE
Moving pip install into virtual environment

### DIFF
--- a/build/docker/Dockerfile.attacker
+++ b/build/docker/Dockerfile.attacker
@@ -4,6 +4,10 @@ RUN apt-get update && \
     apt-get install -y \
     python3 pip ssh telnet
 
-RUN pip install paho-mqtt
+RUN python3 -m venv ./venv
+ENV PATH="./venv/bin:$PATH"
+
+RUN . ./venv/bin/activate && \
+    pip install paho-mqtt
 
 CMD ["bash"]


### PR DESCRIPTION
#83 - Moved all pip install into a virtual environment (file affected: [docker file for attackers](https://github.com/aau-network-security/riotpot/blob/master/build/docker/Dockerfile.attacker)):
```
$ grep -r "pip install" *
build/docker/Dockerfile.attacker:    pip install paho-mqtt
```

This PR will solve #82 

